### PR TITLE
Set up express, node, and npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.node_modules/
+build/*
+.eslintcache

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "ignore": ["src/public"],
+  "exec": "NODE_ENV=development ts-node src/start.ts"
+}

--- a/npm-guide.md
+++ b/npm-guide.md
@@ -1,0 +1,10 @@
+npm is silly, but its effective for getting something started quickly.
+
+General flow when you pull down the repo:
+0. Install `npm` via your preferred method. Its a node package manager/build manager/script runner.
+1. Do `npm install` to install all relevant local packages (these are pulled from the dependencies in package.json)
+2. Build and run the code in your dev environment by running `npm run start-dev`. The server will now be running on localhost:3000. 
+The only endpoint is a GET on localhost:3000/api/game.
+3. To debug, do `npm run build`, which will transpile all ts files to js files and puts those js files in the `build` folder. 
+Then, you can do `npm run debug` to start debugging in start.ts, where the server starts up
+4. Hopefully profit.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "homepage": "https://github.com/PDX-Checkers/checkers#readme",
   "dependencies": {
+    "@overnightjs/core": "^1.6.9",
+    "@overnightjs/logger": "^1.1.9",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "checkers",
+  "version": "1.0.0",
+  "description": "Checkers game",
+  "main": "src/start.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start-dev": "nodemon --config \"./util/nodemon.json\"/",
+    "build": "rm -rf ./build/ && tsc",
+    "start": "node build/start.js",
+    "debug": "node inspect build/start.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PDX-Checkers/checkers.git"
+  },
+  "author": "Mike Bottini & Ryan Lanigan",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/PDX-Checkers/checkers/issues"
+  },
+  "homepage": "https://github.com/PDX-Checkers/checkers#readme",
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.2",
+    "@types/node": "^12.12.5",
+    "nodemon": "^1.19.4",
+    "ts-node": "^8.4.1",
+    "tslint": "^6.0.0-beta0",
+    "typescript": "^3.6.4"
+  }
+}

--- a/src/CheckersServer.ts
+++ b/src/CheckersServer.ts
@@ -24,6 +24,7 @@ class CheckersServer extends Server {
 }
 
   public start(port: number): void {
+    this.app.use(express.static(__dirname));
     this.app.get('*', (req, res) => {
       res.send('Server\'s up. Port: ' + port);
     });

--- a/src/CheckersServer.ts
+++ b/src/CheckersServer.ts
@@ -4,17 +4,16 @@ import { Server } from '@overnightjs/core';
 import { Logger } from '@overnightjs/logger';
 
 class CheckersServer extends Server {
-  
+
   constructor() {
     super(true);
     this.app.use(express.json());
     this.app.use(express.urlencoded({extended: true}));
     this.setupControllers();
-  } 
+  }
 
   private setupControllers(): void {
     const ctlrInstances = [];
-    debugger;
     for (const name in controllers) {
         if (controllers.hasOwnProperty(name)) {
             const controller = (controllers as any)[name];
@@ -27,7 +26,7 @@ class CheckersServer extends Server {
   public start(port: number): void {
     this.app.get('*', (req, res) => {
       res.send('Server\'s up. Port: ' + port);
-  });
+    });
     this.app.listen(port, () => {
       Logger.Info('Server\'s up. Port: ' + port);
     })

--- a/src/CheckersServer.ts
+++ b/src/CheckersServer.ts
@@ -1,0 +1,37 @@
+import * as express from 'express'
+import * as controllers from './controllers';
+import { Server } from '@overnightjs/core';
+import { Logger } from '@overnightjs/logger';
+
+class CheckersServer extends Server {
+  
+  constructor() {
+    super(true);
+    this.app.use(express.json());
+    this.app.use(express.urlencoded({extended: true}));
+    this.setupControllers();
+  } 
+
+  private setupControllers(): void {
+    const ctlrInstances = [];
+    debugger;
+    for (const name in controllers) {
+        if (controllers.hasOwnProperty(name)) {
+            const controller = (controllers as any)[name];
+            ctlrInstances.push(new controller());
+        }
+    }
+    super.addControllers(ctlrInstances);
+}
+
+  public start(port: number): void {
+    this.app.get('*', (req, res) => {
+      res.send('Server\'s up. Port: ' + port);
+  });
+    this.app.listen(port, () => {
+      Logger.Info('Server\'s up. Port: ' + port);
+    })
+  }
+}
+
+export default CheckersServer;

--- a/src/controllers/GameController.ts
+++ b/src/controllers/GameController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { Controller, Get } from '@overnightjs/core';
+import { Logger } from '@overnightjs/logger';
+
+
+@Controller('api/game')
+export class GameController {
+
+  @Get()
+  private getGameState(req: Request, res: Response) {
+    Logger.Info(req.params.msg);
+    res.status(200).json({
+      message: 'Beans'
+    })
+  }
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './GameController'

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,11 @@
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+<body>
+  <h5>Beans</h5>
+</body>
+</html>

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,4 @@
+import CheckersServer from './CheckersServer'
+
+const server = new CheckersServer();
+server.start(3000);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "strict": true,
+    "baseUrl": "./",
+    "outDir": "build",
+    "removeComments": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "emitDecoratorMetadata": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "./src/public/"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,14 @@
+{
+  "extends": "tslint:recommended",
+  "rules": {
+    "max-line-length": {
+      "options": [100]
+    },
+    "member-ordering": false,
+    "no-consecutive-blank-lines": false,
+    "object-literal-sort-keys": false,
+    "ordered-imports": false,
+    "quotemark": [true, "single"],
+    "variable-name": [true, "allow-leading-underscore"]
+  }
+}


### PR DESCRIPTION
Express, node, and npm are now setup.

The express server only has one endpoint, which returns a JSON package
saying "Beans".

Node is set up for running packages and such. All functionality for node
is (currently) tied up in npm scripts so that we can have consistency
across machines.

For instructions on how to run/build the current server setup, see
npm-guide.md.