### PR TITLE
Add folder for Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:eoan
+
+COPY install_deps.sh /install_deps.sh
+RUN bash install_deps.sh
+# system_setup.sh installs dependencies and initializes the database by running
+# secure_installation.sql
+COPY system_setup.sh /system_setup.sh
+COPY secure_installation.sql /secure_installation.sql
+RUN bash system_setup.sh
+
+# Files needed to run the server. run_checkers starts MariaDB, clones the
+# checkers repository, builds the project from source, and starts it.
+# dbConfig.json contains the data that the server will use to connect to
+# MariaDB.
+COPY run_checkers.sh /run_checkers.sh
+COPY docker_dbConfig.json /root/.config/dbConfig.json
+
+# Command that is run when we actually run the Docker container.
+CMD bash run_checkers.sh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build -t checkers_server .

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,32 @@
+This folder contains the files needed for a Docker container that will run
+the Checkers server. The base container is Ubuntu Eoan Ermine.
+
+# Files
+
+* `Dockerfile`, which contains the instructions to modify the base Ubuntu
+container with dependencies and copy files from this directory into the
+container.
+
+* `add_deps.sh`, which runs APT and npm to install dependencies. This is its
+own script because this is a pretty long operation.
+
+* `secure_installation.sql`, which runs a bunch of SQL commands to initialize
+the MariaDB service.
+
+* `system_setup.sh`, which runs the actual meat of the Docker build. It
+installs dependencies and initializes the database with `add_deps.sh` and
+`secure_installation.sql`.
+
+* `run_checkers.sh`, which is the script the Docker container runs to
+clone the Checkers repository, build from source, and run.
+
+* `run_docker.sh`, which is a convenience script to run the Docker container.
+This specifies a few options for running the container with minimal manual
+effort.
+
+* `docker_dbConfig.json`, which contains information for the Checkers server
+to connect to the MariaDB service. Note that this does contain a password,
+but it's solely local to the Docker container.
+
+* `Makefile`, which contains a convenience option for building the Docker
+container.

--- a/docker/docker_dbConfig.json
+++ b/docker/docker_dbConfig.json
@@ -1,0 +1,5 @@
+{
+    "user":"root",
+    "password":"blarg",
+    "host":"localhost"
+}

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -1,4 +1,3 @@
 apt update && apt upgrade -y
 apt install npm mariadb-server git -y
 
-npm install -g nodemon

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -1,0 +1,4 @@
+apt update && apt upgrade -y
+apt install npm mariadb-server git -y
+
+npm install -g nodemon

--- a/docker/run_checkers.sh
+++ b/docker/run_checkers.sh
@@ -3,4 +3,5 @@ service mysql start
 git clone https://github.com/PDX-Checkers/checkers.git
 pushd checkers
     npm install
+    npm run build
     npm run start-dev

--- a/docker/run_checkers.sh
+++ b/docker/run_checkers.sh
@@ -1,0 +1,6 @@
+# Clone the git repository, and then build from source.
+service mysql start
+git clone https://github.com/PDX-Checkers/checkers.git
+pushd checkers
+    npm install
+    npm run start-dev

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -1,0 +1,1 @@
+docker run --rm -p 3000:3000 checkers_server

--- a/docker/secure_installation.sql
+++ b/docker/secure_installation.sql
@@ -1,0 +1,7 @@
+DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
+DROP DATABASE IF EXISTS test;
+DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+CREATE DATABASE checkers;
+FLUSH PRIVILEGES;
+UPDATE mysql.user SET plugin = 'mysql_native_password', 
+      Password = PASSWORD('blarg') WHERE User = 'root';

--- a/docker/system_setup.sh
+++ b/docker/system_setup.sh
@@ -1,0 +1,5 @@
+# Start martiadb-server for setup commands.
+service mysql start
+
+# Run installation SQL script.
+mysql < secure_installation.sql


### PR DESCRIPTION
This serves two purposes:

* Fire-and-forget build tool to build on any system.
* Have an explicit process of building the application *de novo*,
keeping track of all dependencies.