### PR TITLE
Fix Docker run_checkers.sh script

### DIFF
--- a/docker/run_checkers.sh
+++ b/docker/run_checkers.sh
@@ -4,4 +4,4 @@ git clone https://github.com/PDX-Checkers/checkers.git
 pushd checkers
     npm install
     npm run build
-    npm run start-dev
+    npm run start


### PR DESCRIPTION
The script wasn't actually building properly. It should now work
without the nodemon dependency.