### PR TITLE
Rework json responses

### DIFF
--- a/src/BoardClasses/ActiveGame.ts
+++ b/src/BoardClasses/ActiveGame.ts
@@ -83,7 +83,7 @@ export class ActiveGame {
             return;
         }
         if(parsedObj.isStateRequest()) {
-            socket.send(JSON.stringify(new JSONGameStateResponse(this).toObject()));
+            sendResponse(socket, new JSONGameStateResponse(this));
             return;
         }
         // If it's not invalid and it's not a state request, it's a move request.

--- a/src/BoardClasses/ActiveGame.ts
+++ b/src/BoardClasses/ActiveGame.ts
@@ -7,7 +7,8 @@ import { JSONInvalidMessageResponse,
          JSONValidMoveResponse, 
          JSONResponse,
          JSONJoinedGame,
-         JSONCreatedGame} from '../JSONClasses/JSONResponse';
+         JSONCreatedGame,
+         sendResponse} from '../JSONClasses/JSONResponse';
 import OOPEventWebSocket = require('ws');
 import { ActiveGameController, subscribe } from '../controllers/ActiveGameController';
 import { Logger } from '@overnightjs/logger';
@@ -154,8 +155,4 @@ function wsListener(game: ActiveGame, ws: OOPEventWebSocket, color: Color): ((s:
 
 function isOpen(socket: OOPEventWebSocket) {
     return socket.readyState === 1;
-}
-
-function sendResponse(ws: OOPEventWebSocket, response: JSONResponse) {
-    ws.send(JSON.stringify(response.toObject()));
 }

--- a/src/BoardClasses/ActiveGame.ts
+++ b/src/BoardClasses/ActiveGame.ts
@@ -8,7 +8,8 @@ import { JSONInvalidMessageResponse,
          JSONResponse,
          JSONJoinedGame,
          JSONCreatedGame,
-         sendResponse} from '../JSONClasses/JSONResponse';
+         sendResponse,
+         JSONVeryBadResponse} from '../JSONClasses/JSONResponse';
 import OOPEventWebSocket = require('ws');
 import { ActiveGameController, subscribe } from '../controllers/ActiveGameController';
 import { Logger } from '@overnightjs/logger';
@@ -94,7 +95,7 @@ export class ActiveGame {
             }
             let move: [number, number] | null = parsedObj.getMove();
             if(move === null) {
-                socket.send("Something went very, very wrong.");
+                sendResponse(socket, new JSONVeryBadResponse("Move is null???"));
                 return;
             }
             let [source, target]: [number, number] = move;
@@ -124,14 +125,12 @@ export class ActiveGame {
     finishGame() {
         Logger.Info(`Finished Game: ${this.toObject()}`);
         if(isOpen(this.blackSocket)) {
-            this.blackSocket.send("Returning to ActiveGameController");
             subscribe(this.parent, this.blackSocket, this.blackID);
         }
         else {
             this.parent.removeUserSocket(this.blackID);
         }
         if(this.redSocket !== undefined && this.redID !== undefined && isOpen(this.redSocket)) {
-            this.blackSocket.send("Returning to ActiveGameController");
             subscribe(this.parent, this.redSocket, this.redID);
         }
     }

--- a/src/JSONClasses/JSONRequest.ts
+++ b/src/JSONClasses/JSONRequest.ts
@@ -54,18 +54,6 @@ class JSONMoveRequest extends JSONRequest {
     }
 }
 
-/*
-    isGetGamesRequest(): boolean {
-        return false;
-    }
-    isCreateGameRequest(): boolean {
-        return false;
-    }
-    isJoinGameRequest(): boolean {
-        return false;
-    }
-*/
-
 export class JSONGetGamesRequest extends JSONRequest {
     constructor() {
         super();

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -150,3 +150,31 @@ export class JSONActiveGames extends JSONResponse {
         return Array.from(this.games.entries()).map(([x, y]) => [x, y.toObject()])
     }
 }
+
+export class JSONCreatedGame extends JSONResponse {
+    private board: Board;
+    constructor(board: Board) {
+        super();
+        this.board = board;
+    }
+    toObject(): object {
+        return {
+            response_type: "created_game",
+            board_state: this.board.toObject()
+        };
+    }
+}
+
+export class JSONJoinedGame extends JSONResponse {
+    private board: Board;
+    constructor(board: Board) {
+        super();
+        this.board = board;
+    }
+    toObject(): object {
+        return {
+            response_type: "joined_game",
+            board_state: this.board.toObject()
+        };
+    }
+}

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -34,10 +34,12 @@ export abstract class JSONResponse {
 
 export class JSONInvalidMessageResponse extends JSONResponse {
     message: string;
+    board_state ?: Board;
 
-    constructor(message: string) {
+    constructor(message: string, board_state?: Board) {
         super();
         this.message = message;
+        this.board_state = board_state;
     }
 
     isInvalidMessage(): boolean {
@@ -45,10 +47,12 @@ export class JSONInvalidMessageResponse extends JSONResponse {
     }
 
     toObject(): object {
-        return {
-            response_type: "invalid_message",
-            message: this.message
-        };
+        let obj: any = {};
+        obj.response_type = "invalid_message";
+        if(this.board_state !== undefined) {
+            obj.board_state = this.board_state.toObject();
+        }
+        return obj;
     }
 }
 

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -181,5 +181,5 @@ export class JSONJoinedGame extends JSONResponse {
 }
 
 export function sendResponse(ws: OOPEventWebSocket, response: JSONResponse) {
-    ws.send(JSON.stringify(response.toObject()));
+    ws.send(response.toJSON());
 }

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -148,7 +148,10 @@ export class JSONActiveGames extends JSONResponse {
         this.games = controller.games;
     }
     toObject(): object {
-        return Array.from(this.games.entries()).map(([x, y]) => [x, y.toObject()])
+        return {
+            response_type: "active_games",
+            games: Array.from(this.games.entries()).map(([x, y]) => [x, y.toObject()])
+        };
     }
 }
 

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -1,6 +1,7 @@
 import { Board } from '../BoardClasses/Board';
 import { ActiveGame } from '../BoardClasses/ActiveGame';
 import { ActiveGameController } from '../controllers/ActiveGameController';
+import OOPEventWebSocket = require('ws');
 
 export abstract class JSONResponse {
     constructor() {}
@@ -177,4 +178,8 @@ export class JSONJoinedGame extends JSONResponse {
             board_state: this.board.toObject()
         };
     }
+}
+
+export function sendResponse(ws: OOPEventWebSocket, response: JSONResponse) {
+    ws.send(JSON.stringify(response.toObject()));
 }

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -183,6 +183,17 @@ export class JSONJoinedGame extends JSONResponse {
     }
 }
 
+export class JSONJoinedRoom extends JSONResponse {
+    constructor() {
+        super();
+    }
+    toObject(): object {
+        return {
+            response_type: "joined_room"
+        };
+    }
+}
+
 export function sendResponse(ws: OOPEventWebSocket, response: JSONResponse) {
     ws.send(response.toJSON());
 }

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -57,6 +57,22 @@ export class JSONInvalidMessageResponse extends JSONResponse {
     }
 }
 
+export class JSONVeryBadResponse extends JSONResponse {
+    message: string;
+
+    constructor(message: string) {
+        super();
+        this.message = message;
+    }
+
+    toObject(): object {
+        return {
+            response_type: "very_bad_response",
+            message: this.message
+        };
+    }
+}
+
 export class JSONInvalidMoveResponse extends JSONResponse {
     private board: Board;
     constructor(board: Board) {
@@ -179,6 +195,21 @@ export class JSONJoinedGame extends JSONResponse {
         return {
             response_type: "joined_game",
             board_state: this.board.toObject()
+        };
+    }
+}
+
+export class JSONCouldntFindGame extends JSONResponse {
+    gameID: string;
+    constructor(gameID: string) {
+        super();
+        this.gameID = gameID;
+    }
+
+    toObject(): object {
+        return {
+            response_type: "couldnt_find_game",
+            game_id: this.gameID
         };
     }
 }

--- a/src/JSONClasses/JSONResponse.ts
+++ b/src/JSONClasses/JSONResponse.ts
@@ -57,8 +57,10 @@ export class JSONInvalidMessageResponse extends JSONResponse {
 }
 
 export class JSONInvalidMoveResponse extends JSONResponse {
-    constructor() {
+    private board: Board;
+    constructor(board: Board) {
         super();
+        this.board = board;
     }
 
     isInvalidMove(): boolean {
@@ -67,8 +69,9 @@ export class JSONInvalidMoveResponse extends JSONResponse {
 
     toObject(): object {
         return {
-            response_type: "invalid_move"
-        }
+            response_type: "invalid_move",
+            board_state: this.board.toObject()
+        };
     }
 }
 
@@ -119,7 +122,11 @@ export class JSONValidMoveResponse extends JSONResponse {
 }
 
 export class JSONIsNotYourTurnResponse extends JSONResponse {
-    constructor() { super(); }
+    private board: Board;
+    constructor(board: Board) { 
+        super(); 
+        this.board = board;
+    }
 
     isNotYourTurn(): boolean {
         return true;
@@ -127,7 +134,8 @@ export class JSONIsNotYourTurnResponse extends JSONResponse {
 
     toObject(): object {
         return {
-            response_type: "not_your_turn"
+            response_type: "not_your_turn",
+            board_state: this.board.toObject()
         };
     }
 }

--- a/src/controllers/ActiveGameController.ts
+++ b/src/controllers/ActiveGameController.ts
@@ -2,6 +2,7 @@ import { Logger } from '@overnightjs/logger';
 import { ActiveGame } from '../BoardClasses/ActiveGame';
 import { JSONActiveGames, 
          JSONInvalidMessageResponse, 
+         JSONJoinedRoom,
          sendResponse } from '../JSONClasses/JSONResponse';
 import { DbManager } from '../DbManager'
 import { Router, Request } from 'express';
@@ -148,6 +149,7 @@ export function subscribe(controller: ActiveGameController, ws: OOPEventWebSocke
     ws.removeAllListeners();
     ws.on('message', wsListener(controller, ws, username));
     ws.on('close', wsCloser(controller, username));
+    sendResponse(ws, new JSONJoinedRoom());
 }
 
 function wsListener(controller: ActiveGameController, ws: OOPEventWebSocket, username: string): ((s: string) => void) {

--- a/src/controllers/ActiveGameController.ts
+++ b/src/controllers/ActiveGameController.ts
@@ -3,7 +3,9 @@ import { ActiveGame } from '../BoardClasses/ActiveGame';
 import { JSONActiveGames, 
          JSONInvalidMessageResponse, 
          JSONJoinedRoom,
-         sendResponse } from '../JSONClasses/JSONResponse';
+         sendResponse, 
+         JSONVeryBadResponse,
+         JSONCouldntFindGame} from '../JSONClasses/JSONResponse';
 import { DbManager } from '../DbManager'
 import { Router, Request } from 'express';
 import { ParamsDictionary } from 'express-serve-static-core';
@@ -52,7 +54,7 @@ export class ActiveGameController {
             g.join(playerID, ws);
         }
         else {
-            ws.send("Unable to find game");
+            sendResponse(ws, new JSONCouldntFindGame(gameID));
         }
     }
 
@@ -128,7 +130,7 @@ function wsSubscriber(controller: ActiveGameController): ((ws: OOPEventWebSocket
             Logger.Info(`Received websocket connection from ${username}`);
             if(controller.getUserSocket(<string>username)) {
                 Logger.Info(`But it's a duplicate...`);
-                ws.send("You already connected!");
+                sendResponse(ws, new JSONVeryBadResponse("You already connected!"));
                 ws.close();
             }
             // Happy path - subscribes the websocket to the Listener.
@@ -139,7 +141,7 @@ function wsSubscriber(controller: ActiveGameController): ((ws: OOPEventWebSocket
         }
         else {
             Logger.Info("Received unauthorized websocket request.");
-            ws.send("You aren't authenticated, fool!");
+            sendResponse(ws, new JSONVeryBadResponse("You aren't authenticated, fool!"));
             ws.close();
         }
     }

--- a/src/controllers/ActiveGameController.ts
+++ b/src/controllers/ActiveGameController.ts
@@ -1,6 +1,8 @@
 import { Logger } from '@overnightjs/logger';
 import { ActiveGame } from '../BoardClasses/ActiveGame';
-import { JSONActiveGames, JSONInvalidMessageResponse } from '../JSONClasses/JSONResponse';
+import { JSONActiveGames, 
+         JSONInvalidMessageResponse, 
+         sendResponse } from '../JSONClasses/JSONResponse';
 import { DbManager } from '../DbManager'
 import { Router, Request } from 'express';
 import { ParamsDictionary } from 'express-serve-static-core';
@@ -61,12 +63,12 @@ export class ActiveGameController {
         let msgObj: JSONRequest | null = parseMessageJSON(msg);
         if(msgObj === null) {
             Logger.Info(`Got malformed request from ${username}`);
-            ws.send(JSON.stringify(new JSONInvalidMessageResponse("Request was malformed")));
+            sendResponse(ws, new JSONInvalidMessageResponse("Request was malformed"));
             return;
         }
         if(msgObj.isGetGamesRequest()) {
             Logger.Info(`Giving games to ${username}`);
-            ws.send(JSON.stringify(new JSONActiveGames(this).toObject()));
+            sendResponse(ws, new JSONActiveGames(this));
             return;
         }
         if(msgObj.isCreateGameRequest()) {
@@ -77,15 +79,15 @@ export class ActiveGameController {
         if(msgObj.isJoinGameRequest()) {
             let gameID: string | null = msgObj.getGameID();
             if(gameID === null) {
-                Logger.Err("processMessage JoinGameRequest: Something went extremely wrong, gameID is null")
+                Logger.Err("processMessage JoinGameRequest: Something went extremely wrong, gameID is null");
                 return;
             }
             Logger.Info(`${username} is trying to join ${gameID}`);
             this.joinGame(gameID, username, ws);
             return;
         }
-        Logger.Info(`${username} sent a valid request, but it's not for the ActiveGameController.`)
-        ws.send(JSON.stringify(new JSONInvalidMessageResponse("Request was valid, but in the wrong scope")));
+        Logger.Info(`${username} sent a valid request, but it's not for the ActiveGameController.`);
+        sendResponse(ws, new JSONInvalidMessageResponse("Request was valid, but in the wrong scope"));
     }
 
     public getUserSocket(username: string): OOPEventWebSocket | undefined {


### PR DESCRIPTION
Per Issue #26, we're going to eliminate all naked string messages sent through WebSockets. Additionally, if possible, we're going to send the board state through as many messages as possible, including requests to the `ActiveGame` instance that are malformed, on the wrong turn, illegal, or are otherwise invalid.