### PR TITLE
Remove bug allowing pieces to move two spaces

### DIFF
--- a/src/BoardClasses/Board.ts
+++ b/src/BoardClasses/Board.ts
@@ -312,6 +312,12 @@ export class Board {
                            .indexOf(targetIndex) < 0) {
                 return null;
             }
+            // If the player is making a "capture" move, but can't actually capture
+            // that way, return null. 
+            if(Math.abs(sourceIndex - targetIndex) > 6 &&
+               this.findAllCaptures(sourceIndex).indexOf(targetIndex) < 0) {
+                return null;
+            }
             // Otherwise, it's a good move.
             let newBoard: Board = new Board(this.pieces, this.currentState, true);
             for(let i = 0; i < captureMoves.length; i++) {


### PR DESCRIPTION
Added an additional check to ensure that if the piece is moving
two spaces, it needs to actually be able to capture that way.

This fixes Issue #32.